### PR TITLE
Mod loading changes & bugfixes

### DIFF
--- a/src/core/mods.cpp
+++ b/src/core/mods.cpp
@@ -11,6 +11,8 @@
 #endif
 
 bool mods::load(const char *name) {
+	if (mod_list.count(name)) return false;
+
 #ifdef _WIN32
 	void *lib = LoadLibraryA(utils::string::ssprintf("wormhole/%s.dll", name).c_str());
 #else
@@ -45,11 +47,11 @@ bool mods::load(const char *name) {
 }
 
 void mods::unload(const char *name) {
+	if (!mod_list.count(name)) return;
+
 	auto mod = mod_list[name];
 
 	mod.ptr->unload();
-
-	delete_ptr(mod.ptr);
 
 #ifdef _WIN32
 	FreeLibrary((HMODULE)mod.handle);

--- a/src/core/mods.h
+++ b/src/core/mods.h
@@ -2,7 +2,7 @@
 
 #include "wormhole-sdk/wormhole.h"
 
-#include <map>
+#include <unordered_map>
 
 namespace mods {
 	struct mod_info_t {
@@ -10,7 +10,7 @@ namespace mods {
 		wh_api::i_wormhole_mod *ptr;
 	};
 
-	inline std::map<std::string, mod_info_t> mod_list;
+	inline std::unordered_map<std::string, mod_info_t> mod_list;
 
 	bool load(const char *name);
 	void unload(const char *name);


### PR DESCRIPTION
Per wormhole api, the mod is a static/global object, deleting it causes a crash on windows (free called with null, on linux free(NULL) is defined to do nothing, ig MSVC api jank /shrug). Previously, unloading a mod that does not exist caused a null dereference with the assumption that mod was not null on hash map lookup. This commit aims to resolve both of those issues.

Commit details:
- unload no longer crashes on names of not loaded mods
- changed mod map from `std::map` to `std::unordered_map`
- removed useless `delete` call from mod unload